### PR TITLE
Sanitize session cookie domain handling

### DIFF
--- a/core/session_starter.php
+++ b/core/session_starter.php
@@ -8,24 +8,43 @@ if (session_status() === PHP_SESSION_NONE) {
     $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
                || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443);
 
+    $host = isset($_SERVER['HTTP_HOST']) ? trim($_SERVER['HTTP_HOST']) : '';
+
+    if ($host !== '') {
+        // Remove a port suffix to obtain a clean cookie domain.
+        $host = preg_replace('/:\\d+$/', '', $host);
+
+        // Skip invalid cookie domains such as IP addresses or "localhost".
+        if ($host === 'localhost' || filter_var($host, FILTER_VALIDATE_IP)) {
+            $host = '';
+        }
+    }
+
     $params = [
       'lifetime' => 0,
       'path'     => '/',
-      'domain'   => '', // Dikosongkan untuk fleksibilitas
       'secure'   => $isHttps,
       'httponly' => true,
       'samesite' => $samesite
     ];
 
+    if ($host !== '') {
+        $params['domain'] = $host;
+    }
+
     if (PHP_VERSION_ID >= 70300) {
         session_set_cookie_params($params);
     } else {
+        ini_set('session.cookie_secure', $params['secure'] ? '1' : '0');
+        ini_set('session.cookie_httponly', $params['httponly'] ? '1' : '0');
+
+        if (isset($params['domain'])) {
+            ini_set('session.cookie_domain', $params['domain']);
+        }
+
         session_set_cookie_params(
             $params['lifetime'],
-            $params['path'] . '; SameSite=' . $params['samesite'],
-            $params['domain'],
-            $params['secure'],
-            $params['httponly']
+            $params['path'] . '; SameSite=' . $params['samesite']
         );
     }
 


### PR DESCRIPTION
## Summary
- derive the cookie domain from HTTP_HOST and ignore invalid values so empty domain attributes are never emitted
- reuse the sanitized cookie parameters for both the PHP 7.3+ API and the legacy fallback branch
- configure legacy environments via ini settings before calling session_set_cookie_params

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce7d0a7c7c832c8b96ea94232b66f2